### PR TITLE
QE-164: Avoid browser restart for every scenario

### DIFF
--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -37,6 +37,7 @@ exports.config = {
       smartWait: 5000,
       waitForTimeout: 5000,
       testName: '',
+      restart: false,
     },
     Mochawesome: {
       uniqueScreenshotNames: true,


### PR DESCRIPTION
Jira: [QE-164](https://jira.bigcommerce.com/browse/QE-164)

## What? Why?
With current configuration browser is restarted for every scenario we have in our tests. This to me feels like an overhaul and we can manage this better by handling browser session as part of setup and teardown process. Ideally, opening and closing browser for every spec(test file) is a better alternative to the current setup. 

The change I have in here doesn't terminate the browser on every scenario but does clear up cookies between each spec. I've confirmed this after reading through codeceptjs documentation.

## How was it tested?
Tested locally with existing specs

- [ ] Cloud Dev end-to-end - Describe Steps
- [ ] Additional test cases (Optional)
- [ ] Integration - Describe Steps (Optional)

## How can this be undone?
1. Revert this PR

ping @bigcommerce/billing-iam-testing
