### PR TITLE
feat(qpt): QPT-182 Fix current implementation of create-account service

### DIFF
--- a/src/services/create-account.js
+++ b/src/services/create-account.js
@@ -1,43 +1,66 @@
 import faker from 'faker';
 import StoreSetupService from 'bc-store-setup-node';
 import Globals from './../global-constants';
-import AccountData from '../../test/fixtures/account-data';
 
-function _buildCreateAccountPayload(email) {
+function _buildCreateAccountPayload(emailAddr) {
   const contactAttributes = {
-    first_name: faker.name.firstName,
-    last_name: faker.name.lastName,
-    email_address: email,
-    street_address_1: faker.address.streetAddress,
-    city: faker.address.city,
-    state: faker.address.state,
-    postal_code: faker.address.postalCode,
-    phone_country_code: faker.address.phoneCountryCode,
-    phone_number: faker.address.phoneNumber,
+    first_name: faker.name.firstName(),
+    last_name: faker.name.lastName(),
+    email_address: emailAddr,
+    street_address_1: '211 E 7th Street',
+    city: 'Austin',
+    state: 'TX',
+    postal_code: '78701',
+    phone_country_code: '1',
+    phone_number: '8181818181',
     country: 'US'
   };
+
   return JSON.stringify({
     data: {
-      email_address: email,
+      email_address: contactAttributes.email_address,
       first_name: contactAttributes.first_name,
-      last_name: contactAttributes.last_name,
-      company_name: faker.company.companyName,
+      last_name: contactAttributes.lastName,
+      company_name: faker.company.companyName(),
       password: Globals.TEST_USER_PASSWORD,
       primary_contact_attributes: contactAttributes,
-      billing_contact_attributes: contactAttributes
-    }
+      billing_contact_attributes: contactAttributes,
+    },
   });
 }
 
-export async function createAccount(email) {
-  console.log(`\nCreating an account with email and password: ${email} and ${AccountData.password}`);
-  const createAccountPayload = _buildCreateAccountPayload(email);
+function _buildCreateTrialAccountPayload(emailAddr) {
+  const contactAttributes = {
+    first_name: faker.name.firstName(),
+    last_name: faker.name.lastName(),
+    email_address: emailAddr,
+    is_trial: 1,
+    state: 'TX',
+    country: 'US'
+  };
+
+  return JSON.stringify({
+    data: {
+      email_address: emailAddr,
+      company_name: faker.company.companyName(),
+      password: Globals.TEST_USER_PASSWORD,
+      primary_contact_attributes: contactAttributes,
+      billing_contact_attributes: contactAttributes,
+    },
+  });
+}
+
+async function createAccount(emailAddr, type) {
+  console.log(`\nCreating an account with email : ${emailAddr}`);
+  const createAccountPayload = (type === 'non-trial' ? _buildCreateAccountPayload(emailAddr) : _buildCreateTrialAccountPayload(emailAddr));
   try {
     const store = new StoreSetupService(Globals.BMP_HOST, Globals.CLIENT_ID, Globals.CLIENT_SECRET);
     return await store.createAccount(createAccountPayload);
-  } catch {
-    const message = `Account creation failed for ${email}!`;
+  } catch(error) {
+    const message = `Account creation failed for ${emailAddr}!`;
     console.log(message);
     throw message;
   }
 }
+
+module.exports = createAccount;

--- a/test/functional/examples/create-account-example-spec.js
+++ b/test/functional/examples/create-account-example-spec.js
@@ -1,0 +1,9 @@
+const createAccount = require('../../../src/services/create-account');
+
+Feature('Account creation example spec');
+
+Scenario('test create account workflow', async() => {
+    const emailAddr = `auto-${new Date().getTime()}@bigcommerce.com`;
+    const res = await createAccount(emailAddr, 'non-trial');
+    console.log(res);
+});

--- a/test/mocks/create-account-mocks.js
+++ b/test/mocks/create-account-mocks.js
@@ -4,7 +4,7 @@ import matches from 'lodash.matches';
 
 export const createAccountSuccessResp = {
   email: 'example@example.com',
-  company_name: AccountData.companyName,
+  company_name: 'Bigcommerce',
   password: AccountData.password
 };
 
@@ -14,9 +14,7 @@ export const createAccountErrorResp = {
 
 const matcherDataLocal = {
   data: {
-    primary_contact_attributes: {
-      country: 'US'
-    }
+    email_address: 'example@example.com'
   }
 };
 
@@ -28,7 +26,7 @@ export const createAccountFailureMock = () => {
 
 export const createAccountBcSetupNodeSuccessMock = () => {
   nock(/https/)
-    .matchHeader('accept', 'application/json, text/plain, */*')
+    .matchHeader('Content-Type', 'application/json')
     .post('/api/v1/accounts/', matches(matcherDataLocal))
     .reply(200, createAccountSuccessResp)
 };

--- a/test/services/create-account-test.js
+++ b/test/services/create-account-test.js
@@ -3,7 +3,7 @@ import {
   createAccountBcSetupNodeSuccessMock,
   createAccountSuccessResp
 } from '../mocks/create-account-mocks';
-import { createAccount } from './../../src/services/create-account';
+const createAccount = require('./../../src/services/create-account');
 
 require('regenerator-runtime');
 
@@ -12,7 +12,7 @@ describe('createAccount', () => {
     createAccountFailureMock();
     expect.assertions(1);
     try {
-      await createAccount('example@example.com');
+      await createAccount('example@example.com', 'non-trial');
     } catch(e) {
       expect(e).toEqual("Account creation failed for example@example.com!")
     }
@@ -20,7 +20,7 @@ describe('createAccount', () => {
 
   it('returns the body on success', async () => {
     createAccountBcSetupNodeSuccessMock();
-    const res = await createAccount('example@example.com');
+    const res = await createAccount('example@example.com', 'non-trial');
     expect(res).toMatchObject(createAccountSuccessResp);
   });
 });


### PR DESCRIPTION
Jira: [QE-182](https://jira.bigcommerce.com/browse/QE-182)

## What? Why?
Current implementation of create-account-service is incorrect and had to be fixed. We previously missed that the email address had to be unique for every request so having a test name for the account wouldn't work. Also, the payload for a trial account and a non-trial account are different so included that as part of this change. Changed the catch block to handle display the error correctly. 


## How was it tested?
Added test to example spec and ran the test locally.

- [ ] Cloud Dev end-to-end - Describe Steps
- [x] Additional test cases (Optional)
- [ ] Integration - Describe Steps (Optional)

## Testing / Proof
<br/>
<img width="644" alt="create-account-service" src="https://user-images.githubusercontent.com/58529077/91094378-535a7300-e620-11ea-8f7f-22c245209ad0.png">
<br/>

## How can this be undone?
1. Revert this PR

ping @bigcommerce/billing-iam-testing
