### PR TITLE
fix(QPT): QE-184 Lock chromedriver version to fix test runner

### DIFF
--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -92,7 +92,22 @@ exports.config = {
     },
     wdio: {
       enabled: true,
-      services: ['selenium-standalone']
+      services: ['selenium-standalone'],
+      seleniumInstallArgs: {
+        drivers: {
+          chrome: {
+            version: '85.0.4183.83',
+            baseURL: "https://chromedriver.storage.googleapis.com"
+          }
+        }
+      },
+      seleniumArgs: {
+        drivers: {
+          chrome: {
+            version: '85.0.4183.83'
+          }
+        }
+      }
     }
   }
 };

--- a/test/functional/billing/account-spec.js
+++ b/test/functional/billing/account-spec.js
@@ -1,6 +1,6 @@
 import {BMP_HOST, TEST_USER_EMAIL, TEST_USER_PASSWORD} from '../../../src/global-constants'
 
-Feature.skip('Client UI: Account');
+Feature('Client UI: Account');
 
 Before((I, loginHelper) => {
     I.amOnPage(BMP_HOST);


### PR DESCRIPTION

Jira: [QE-184](https://jira.bigcommerce.com/browse/QE-184)

## What? Why?
With the recent upgrade to chrome browser v 85, chromedriver v83 was incompatible and was broken. Codeceptjs was installing chromedriver v 83 causing tests to fail both locally and on cloud.

To fix that, we are locking a specific chromedriver version in wdio config within codecept.js. This can be a potential fix but for now we are considering this a temporary remedy to unblock development locally and pushing the code. 

If introducing a new structure or paradigm into the code or if adding a new helper or utility, use this as an opportunity to describe it.
- Locked the chromedriver version to install and run the tests

## Additional Deploy Steps? (Optional)
None

## How was it tested?
Was able to run specs locally

- [ ] Cloud Dev end-to-end - Describe Steps
- [ ] Additional test cases (Optional)
- [ ] Integration - Describe Steps (Optional)

## How can this be undone?
1. Revert this PR

ping @bigcommerce/billing-iam-testing
